### PR TITLE
Added nix packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ konfyt.pro.user*
 moc_*
 qrc_*
 ui_*
-
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1702233072,
+        "narHash": "sha256-H5G2wgbim2Ku6G6w+NSaQaauv6B6DlPhY9fMvArKqRo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "781e2a9797ecf0f146e81425c822dca69fe4a348",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Konfyt, Digital Keyboard Workstation for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+      in
+      rec {
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "konfyt";
+          src = ./.;
+
+          nativeBuildInputs = with pkgs.qt5; [ qmake wrapQtAppsHook ];
+          buildInputs = with pkgs; [
+            qt5.full
+            liblscp
+            linuxsampler
+            pkg-config
+            carla
+            fluidsynth
+            jack2
+          ];
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp konfyt $out/bin
+            wrapProgram $out/bin/konfyt --set PATH ${pkgs.lib.makeBinPath [ pkgs.linuxsampler ]}
+          '';
+        };
+      });
+}
+


### PR DESCRIPTION
Hi, I just added Nix flake support.

In case you dont know anything about this: Nix (https://nixos.org/) is a package manager, and I did this just because I am using a distro based on it, and with this small change I can have konfyt installed as a package directly from the repository

But if you install nix on other distros this can be useful too, since you can use from the project directory:
* `$ nix develop` which will drop you in a shell with all the dependencies needed to build the project
* `$ nix build` which should create a `result/bin/konfyt` binary ready to run

And even from any system you should be able to run it without installing any dependency:
* `$ nix run github:noedigcode/konfyt`  or if you want to test from my current branch: `$ nix run github:pho/konfyt/nix`

If you wanna learn more about this, please check https://zero-to-nix.com/